### PR TITLE
feature: add new ppd types for files and mc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sinet/validation",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/schemas/observation/master-prescribed-resource.js
+++ b/schemas/observation/master-prescribed-resource.js
@@ -4,8 +4,8 @@ var Joi = require( 'joi' );
 
 module.exports = {
 	'id'                     : Joi.string().guid().required().description( 'The resource id' ),
-	'resourceId'             : Joi.number().integer().required().description( 'The id for the resource itself (e.g. contentId, groupId)' ),
-	'type'                   : Joi.any().required().valid( [ 1 ] ).description( 'The resource type (e.g. 1 for content)' ),
+	'resourceId'             : Joi.any().required().description( 'The id for the resource itself (e.g. contentId, groupId, fileId )' ),
+	'type'                   : Joi.any().required().valid( [ 1, 2, 3 ] ).description( 'The resource type (e.g. 1 for content, 2 for files, 3 for mc)' ),
 	'name'                   : Joi.forbidden(),
 	'description'            : Joi.forbidden(),
 	'segmentLengthInSeconds' : Joi.forbidden(),


### PR DESCRIPTION
- change `resourceId` validation type to .any() to cater both guid and integer
- bump to 1.3.8